### PR TITLE
Fix missing return statements in module stubs

### DIFF
--- a/twofish.c
+++ b/twofish.c
@@ -42,5 +42,5 @@ DL_EXPORT(void) exp_Twofish_decrypt(Twofish_key * xkey, uint8_t c[16], uint8_t p
 We need a stub init_twofish function so the module will link as a proper module.
 Do not import _twofish from python; it will not work since _twofish is not a *real* module
 */
-PyMODINIT_FUNC init_twofish(void) { }
-PyMODINIT_FUNC PyInit__twofish(void) { }
+PyMODINIT_FUNC init_twofish(void) { return NULL; }
+PyMODINIT_FUNC PyInit__twofish(void) { return NULL; }


### PR DESCRIPTION
* fixes build with -Werror=return-type
  twofish.c: In function 'init_twofish':
  twofish.c:45:1: error: control reaches end of non-void function [-Werror=return-type]
     45 | PyMODINIT_FUNC init_twofish(void) { }
        | ^~~~~~~~~~~~~~
  twofish.c: In function 'PyInit__twofish':
  twofish.c:46:1: error: control reaches end of non-void function [-Werror=return-type]
     46 | PyMODINIT_FUNC PyInit__twofish(void) { }
        | ^~~~~~~~~~~~~~
  cc1: some warnings being treated as errors

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>