### PR TITLE
setup.py: switch from distutils to setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ Copyright (c) 2013 Keybase
 setup.py - build and package info
 """
 
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 
 twofish_module = Extension('_twofish',
                           sources=['twofish-0.3/twofish.c', 'twofish.c'],


### PR DESCRIPTION
In Python 3.10, distutils is deprecated and will be removed in Python
3.12. Switching to setuptools now allows for setup.py bdist_wheel.

Fixes: https://github.com/keybase/python-twofish/issues/8

Signed-off-by: Tim Orling <tim.orling@konsulko.com>